### PR TITLE
130.0.7

### DIFF
--- a/src/isolate_create_params.rs
+++ b/src/isolate_create_params.rs
@@ -191,6 +191,13 @@ impl CreateParams {
     self
   }
 
+  /// Sets the size of V8's CodeRange (executable-memory cage) in megabytes. Use multiples of 16MB for best compatibility.
+  pub fn code_range_size(mut self, size_mb: usize) -> Self {
+    const MB: usize = 1024 * 1024;
+    self.raw.constraints.set_code_range_size(size_mb * MB);
+    self
+  }
+
   /// A CppHeap used to construct the Isolate. V8 takes ownership of the
   /// CppHeap passed this way.
   pub fn cpp_heap(mut self, heap: UniqueRef<Heap>) -> Self {
@@ -334,6 +341,11 @@ pub(crate) mod raw {
           virtual_memory_limit,
         )
       }
+    }
+
+    /// Sets the CodeRange size in bytes. Must be a multiple of 16MB.
+    pub fn set_code_range_size(&mut self, bytes: usize) {
+      self.code_range_size_ = bytes;
     }
   }
 }

--- a/src/isolate_create_params.rs
+++ b/src/isolate_create_params.rs
@@ -191,13 +191,6 @@ impl CreateParams {
     self
   }
 
-  /// Sets the size of V8's CodeRange (executable-memory cage) in megabytes. Use multiples of 16MB for best compatibility.
-  pub fn code_range_size(mut self, size_mb: usize) -> Self {
-    const MB: usize = 1024 * 1024;
-    self.raw.constraints.set_code_range_size(size_mb * MB);
-    self
-  }
-
   /// A CppHeap used to construct the Isolate. V8 takes ownership of the
   /// CppHeap passed this way.
   pub fn cpp_heap(mut self, heap: UniqueRef<Heap>) -> Self {
@@ -341,11 +334,6 @@ pub(crate) mod raw {
           virtual_memory_limit,
         )
       }
-    }
-
-    /// Sets the CodeRange size in bytes. Must be a multiple of 16MB.
-    pub fn set_code_range_size(&mut self, bytes: usize) {
-      self.code_range_size_ = bytes;
     }
   }
 }


### PR DESCRIPTION
- **feat: add riscv64 musl librusty v8 archive**
- **feat: add riscv64 musl librusty v8 archive with sandbox disabled**
- **feat: add riscv64 musl librusty v8 archive with sandbox and pointer compression  disabled**
- **feat: add riscv64 musl librusty v8 archive with sandbox, pointer compression and caged heap  disabled**
- **feat: rusty_v8 enables setting code_range size**
- **feat: librusty allows setting code range size + default option in args.gn**
- **feat: disable large cage**
- **feat: revert last 6 commits**
- **feat: add riscv64 musl librusty v8 archive with sandbox, pointer compression and caged heap  disabled**
