### PR TITLE
chore(nix): nixfiy build environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ third_party/android_ndk
 third_party/android_platform
 third_party/catapult
 third_party/llvm-build
+
+librusty_v8/

--- a/01_PATCH_RISCV_TOOLCHAIN.patch
+++ b/01_PATCH_RISCV_TOOLCHAIN.patch
@@ -1,0 +1,13 @@
+diff --git a/toolchain/linux/BUILD.gn b/toolchain/linux/BUILD.gn
+index 00e866896..7bb1d9a25 100644
+--- a/toolchain/linux/BUILD.gn
++++ b/toolchain/linux/BUILD.gn
+@@ -306,7 +306,7 @@ clang_toolchain("clang_riscv64") {
+ }
+ 
+ gcc_toolchain("riscv64") {
+-  toolprefix = "riscv64-linux-gnu"
++  toolprefix = "riscv64-unknown-linux-musl"
+ 
+   cc = "${toolprefix}-gcc"
+   cxx = "${toolprefix}-g++"

--- a/02_PATCH_V8_INTERNAL.patch
+++ b/02_PATCH_V8_INTERNAL.patch
@@ -1,0 +1,22 @@
+diff --git a/include/v8-internal.h b/include/v8-internal.h
+index a13db2bd74..77cbf8fc02 100644
+--- a/include/v8-internal.h
++++ b/include/v8-internal.h
+@@ -1430,7 +1430,7 @@ struct MaybeDefineIteratorConcept {};
+ template <typename Iterator>
+ struct MaybeDefineIteratorConcept<
+     Iterator, std::enable_if_t<kHaveIteratorConcept<Iterator>>> {
+-  using iterator_concept = Iterator::iterator_concept;
++  using iterator_concept = typename Iterator::iterator_concept;
+ };
+ // Otherwise fall back to `std::iterator_traits<Iterator>` if possible.
+ template <typename Iterator>
+@@ -1443,7 +1443,7 @@ struct MaybeDefineIteratorConcept<
+   // TODO(pkasting): Add this unconditionally after dropping support for old
+   // libstdc++ versions.
+ #if __has_include(<ranges>)
+-  using iterator_concept = std::iterator_traits<Iterator>::iterator_concept;
++  using iterator_concept = typename std::iterator_traits<Iterator>::iterator_concept;
+ #endif
+ };
+ 

--- a/args.gn
+++ b/args.gn
@@ -1,0 +1,16 @@
+target_os="linux"
+target_cpu="riscv64"
+v8_target_cpu="riscv64"
+is_clang=false
+use_sysroot=false
+use_custom_libcxx=false
+is_component_build=false 
+is_debug=false
+symbol_level=0
+treat_warnings_as_errors=false
+remove_gn_flags=["-gdwarf-4","-gline-tables-only"]
+v8_deprecation_warnings=false
+v8_enable_sandbox=false
+v8_enable_pointer_compression=false
+cppgc_enable_caged_heap=false
+cppgc_enable_larger_cage=false

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -xe
+
+export GN_ARGS=$(cat args.gn | tr '\n' ' ' )
+
+V8_FROM_SOURCE=1 cargo build -vv --release --target riscv64gc-unknown-linux-musl
+
+mkdir -p librusty_v8
+
+cp target/riscv64gc-unknown-linux-musl/release/gn_out/src_binding.rs librusty_v8/src_binding.rs
+cp target/riscv64gc-unknown-linux-musl/release/gn_out/obj/librusty_v8.a librusty_v8/librusty_v8.a
+cp target/riscv64gc-unknown-linux-musl/release/gn_out/args.gn librusty_v8/args.gn
+tar -czf librusty_v8.tar.gz librusty_v8
+

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,95 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1743778823,
+        "narHash": "sha256-5Sh5ECqeQeZfuU+woL8It7iBeQjTjdp7jDxqNLJ3/8Y=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "b2f3696bc0f77b763823acb5440197af6302badb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1744536153,
+        "narHash": "sha256-awS2zRgF4uTwrOKwwiJcByDzDOdo3Q1rPZbiHQg/N38=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "18dd725c29603f582cf1900e0d25f9f1063dbf11",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1752720268,
+        "narHash": "sha256-XCiJdtXIN09Iv0i1gs5ajJ9CVHk537Gy1iG/4nIdpVI=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "dc221f842e9ddc8c0416beae8d77f2ea356b91ae",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,50 @@
+{
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs";
+    flake-utils.url = "github:numtide/flake-utils";
+    rust-overlay.url = "github:oxalica/rust-overlay";
+  };
+  outputs = inputs:
+    with inputs;
+      flake-utils.lib.eachDefaultSystem (system: let 
+	pkgs = import nixpkgs { inherit system; overlays = [(import rust-overlay)]; };
+	riscv64MuslPkgs = let 
+		pkgs = import nixpkgs {
+             		inherit system;
+              		crossSystem.config = "riscv64-unknown-linux-musl";
+            	};
+	  	in
+	  	pkgs.pkgsCross.riscv64;
+	cppInclude = "${riscv64MuslPkgs.pkgsStatic.stdenv.cc.cc}/include/c++/${riscv64MuslPkgs.pkgsStatic.stdenv.cc.version}";
+	llvmPackages = pkgs.llvmPackages_14;
+	libclang = llvmPackages.libclang;
+	rustToolchain = let
+		toolchain = (builtins.fromTOML (builtins.readFile ./rust-toolchain.toml)).toolchain;
+		in
+		pkgs.rust-bin.fromRustupToolchain toolchain;
+	in
+        {
+	   packages.default = pkgs.stdenv.mkDerivation rec {
+           	name = "empty";
+                src = null;
+                phases = [];
+                dontBuild = true;
+                dontInstall = true;
+            };
+
+	   devShells.default = pkgs.mkShell {
+	    	LIBCLANG_PATH = "${libclang.lib}/lib";
+		
+		BINDGEN_EXTRA_CLANG_ARGS_riscv64gc_unknown_linux_musl="--sysroot=${riscv64MuslPkgs.pkgsStatic.stdenv.cc.libc.dev} -isystem ${cppInclude} -isystem ${cppInclude}/riscv64-unknown-linux-musl";
+		buildInputs = with pkgs; 
+			[
+	      			libclang
+	      			riscv64MuslPkgs.pkgsStatic.stdenv.cc
+	      			rustToolchain
+				python310	
+				stgit
+				ccache		
+			];	
+	  };
+        });
+}

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,11 +2,5 @@
 channel = "1.82.0"
 components = ["rustfmt", "clippy"]
 targets = [
-    "x86_64-apple-darwin",
-    "aarch64-apple-darwin",
-    "x86_64-unknown-linux-gnu",
-    "aarch64-unknown-linux-gnu",
-    "x86_64-pc-windows-msvc",
-    "aarch64-linux-android",
-    "x86_64-linux-android",
+	"riscv64gc-unknown-linux-musl"
 ]

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -xe
+git submodule update --init --recursive
+
+python build/install-build-deps.py
+
+# Required on linux (see https://github.com/jstz-dev/rusty_v8?tab=readme-ov-file#build-v8-from-source)
+sudo apt install libglib2.0-dev
+
+(cd build && git apply ../01_PATCH_RISCV_TOOLCHAIN.patch)
+(cd v8 && git apply ../02_PATCH_V8_INTERNAL.patch)

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,2 @@
+(builtins.getFlake (toString ./.)).devShells.${builtins.currentSystem}.default
+


### PR DESCRIPTION
# Context
This PR is to make building v8 targeting `riscv64gc-unknown-linux-musl` nix portable across any linux machine and additionally make it easy to re-build and archive the output as expected by in Jstz

EDIT: My attempt to some what nixify the build fails as the compiled kernel will hang within the riscv sandbox - The last time this happened, it was caused by a compilation bug which I think is the case here but it is too time consuming to debug. My suspicions are
- The `python build/install-build-deps.py` is bringing in riscv musl incompatible libraries which we can get around this by creating a truly pure nix build 
- The `libstdc++` using in bindgen is not being configured correctl

# Description
This PR brings in tools required for the v8 build environment. Specifically, it brings in
1. Rust 1.82.0 toolchain
2. RISCV-64 musl toolchain
3. LLVM 14
4. stGit (nice to have)

This PR also does the following
1. Adds `riscv64gc-unknown-linux-musl` and removes all other targets
2. Adds`setup.sh` for initializing submodules, pulling dependencies and applying patches
3. Adds `build.sh` to build and archive output