### PR TITLE
chore(nix): build env partially with nix, mainly with static tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ third_party/android_ndk
 third_party/android_platform
 third_party/catapult
 third_party/llvm-build
+
+librusty_v8/
+riscv64-linux-musl-cross*

--- a/01_PATCH_RISCV_TOOLCHAIN.patch
+++ b/01_PATCH_RISCV_TOOLCHAIN.patch
@@ -1,0 +1,13 @@
+diff --git a/toolchain/linux/BUILD.gn b/toolchain/linux/BUILD.gn
+index 00e866896..7bb1d9a25 100644
+--- a/toolchain/linux/BUILD.gn
++++ b/toolchain/linux/BUILD.gn
+@@ -306,7 +306,7 @@ clang_toolchain("clang_riscv64") {
+ }
+ 
+ gcc_toolchain("riscv64") {
+-  toolprefix = "riscv64-linux-gnu"
++  toolprefix = "riscv64-linux-musl"
+ 
+   cc = "${toolprefix}-gcc"
+   cxx = "${toolprefix}-g++"

--- a/02_PATCH_V8_INTERNAL.patch
+++ b/02_PATCH_V8_INTERNAL.patch
@@ -1,0 +1,22 @@
+diff --git a/include/v8-internal.h b/include/v8-internal.h
+index a13db2bd74..77cbf8fc02 100644
+--- a/include/v8-internal.h
++++ b/include/v8-internal.h
+@@ -1430,7 +1430,7 @@ struct MaybeDefineIteratorConcept {};
+ template <typename Iterator>
+ struct MaybeDefineIteratorConcept<
+     Iterator, std::enable_if_t<kHaveIteratorConcept<Iterator>>> {
+-  using iterator_concept = Iterator::iterator_concept;
++  using iterator_concept = typename Iterator::iterator_concept;
+ };
+ // Otherwise fall back to `std::iterator_traits<Iterator>` if possible.
+ template <typename Iterator>
+@@ -1443,7 +1443,7 @@ struct MaybeDefineIteratorConcept<
+   // TODO(pkasting): Add this unconditionally after dropping support for old
+   // libstdc++ versions.
+ #if __has_include(<ranges>)
+-  using iterator_concept = std::iterator_traits<Iterator>::iterator_concept;
++  using iterator_concept = typename std::iterator_traits<Iterator>::iterator_concept;
+ #endif
+ };
+ 

--- a/args.gn
+++ b/args.gn
@@ -1,0 +1,17 @@
+target_os="linux"
+target_cpu="riscv64"
+v8_target_cpu="riscv64"
+is_clang=false
+use_sysroot=false
+use_custom_libcxx=false
+use_glib=false
+is_component_build=false 
+is_debug=false
+symbol_level=0
+treat_warnings_as_errors=false
+remove_gn_flags=["-gdwarf-4","-gline-tables-only"]
+v8_deprecation_warnings=false
+v8_enable_sandbox=false
+v8_enable_pointer_compression=true
+cppgc_enable_caged_heap=true
+cppgc_enable_larger_cage=false

--- a/build.rs
+++ b/build.rs
@@ -20,6 +20,13 @@ use std::process::Stdio;
 use which::which;
 
 fn main() {
+
+  let target_arch = std::env::var("CARGO_CFG_TARGET_ARCH").unwrap();
+  if target_arch == "riscv64" {
+    println!("cargo:rustc-link-arg=-static");
+    println!("cargo:rustc-link-arg=-latomic");
+    println!("cargo:rustc-link-lib=atomic");
+  }
   println!("cargo:rerun-if-changed=.gn");
   println!("cargo:rerun-if-changed=BUILD.gn");
   println!("cargo:rerun-if-changed=src/binding.cc");
@@ -166,6 +173,7 @@ fn build_binding() {
     "cargo:rustc-env=RUSTY_V8_SRC_BINDING_PATH={}",
     out_path.display()
   );
+
   bindings
     .write_to_file(out_path)
     .expect("Couldn't write bindings!");

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -xe
+
+cargo clean
+
+export PATH="$HOME/rusty-v8-no-nix/riscv64-linux-musl-cross/bin:$PATH"
+export SYSROOT="$HOME/rusty-v8-no-nix/riscv64-linux-musl-cross/riscv64-linux-musl"
+export BINDGEN_EXTRA_CLANG_ARGS="-target riscv64-unknown-linux-musl -static --sysroot=$SYSROOT -I$SYSROOT/include/c++/11.2.1 -I$SYSROOT/include/c++/11.2.1/riscv64-linux-musl"
+
+export GN_ARGS=$(cat args.gn | tr '\n' ' ' )
+
+V8_FROM_SOURCE=1 cargo build -vv --release --target riscv64gc-unknown-linux-musl
+
+mkdir -p librusty_v8
+
+cp target/riscv64gc-unknown-linux-musl/release/gn_out/src_binding.rs librusty_v8/src_binding.rs
+cp target/riscv64gc-unknown-linux-musl/release/gn_out/obj/librusty_v8.a librusty_v8/librusty_v8.a
+cp target/riscv64gc-unknown-linux-musl/release/gn_out/args.gn librusty_v8/args.gn
+tar -czf librusty_v8.tar.gz librusty_v8
+

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,95 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1743778823,
+        "narHash": "sha256-5Sh5ECqeQeZfuU+woL8It7iBeQjTjdp7jDxqNLJ3/8Y=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "b2f3696bc0f77b763823acb5440197af6302badb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1744536153,
+        "narHash": "sha256-awS2zRgF4uTwrOKwwiJcByDzDOdo3Q1rPZbiHQg/N38=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "18dd725c29603f582cf1900e0d25f9f1063dbf11",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1752720268,
+        "narHash": "sha256-XCiJdtXIN09Iv0i1gs5ajJ9CVHk537Gy1iG/4nIdpVI=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "dc221f842e9ddc8c0416beae8d77f2ea356b91ae",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,39 @@
+{
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs";
+    flake-utils.url = "github:numtide/flake-utils";
+    rust-overlay.url = "github:oxalica/rust-overlay";
+  };
+  outputs = inputs:
+    with inputs;
+      flake-utils.lib.eachDefaultSystem (system: let 
+	pkgs = import nixpkgs { inherit system; overlays = [(import rust-overlay)]; };
+	llvmPackages = pkgs.llvmPackages_14;
+	libclang = llvmPackages.libclang;
+	rustToolchain = let
+		toolchain = (builtins.fromTOML (builtins.readFile ./rust-toolchain.toml)).toolchain;
+		in
+		pkgs.rust-bin.fromRustupToolchain toolchain;
+	in
+        {
+	   packages.default = pkgs.stdenv.mkDerivation rec {
+           	name = "empty";
+                src = null;
+                phases = [];
+                dontBuild = true;
+                dontInstall = true;
+            };
+
+	   devShells.default = pkgs.mkShell {
+	    	LIBCLANG_PATH = "${libclang.lib}/lib";
+		
+		buildInputs = with pkgs; 
+			[
+	      			rustToolchain
+				python310	
+				stgit
+				ccache		
+			];	
+	  };
+        });
+}

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,11 +2,5 @@
 channel = "1.82.0"
 components = ["rustfmt", "clippy"]
 targets = [
-    "x86_64-apple-darwin",
-    "aarch64-apple-darwin",
-    "x86_64-unknown-linux-gnu",
-    "aarch64-unknown-linux-gnu",
-    "x86_64-pc-windows-msvc",
-    "aarch64-linux-android",
-    "x86_64-linux-android",
+	"riscv64gc-unknown-linux-musl"
 ]

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -xe
+
+if [ ! -d "riscv64-linux-musl-cross" ]; then
+	curl -O -L https://musl.cc/riscv64-linux-musl-cross.tgz
+	tar -xzf riscv64-linux-musl-cross.tgz
+	rm riscv64-linux-musl-cross.tgz 
+fi
+
+git submodule update --init --recursive
+
+python build/install-build-deps.py
+
+# Required on linux (see https://github.com/jstz-dev/rusty_v8?tab=readme-ov-file#build-v8-from-source)
+sudo apt install libglib2.0-dev
+
+(cd build && git apply ../01_PATCH_RISCV_TOOLCHAIN.patch)
+(cd v8 && git apply ../02_PATCH_V8_INTERNAL.patch)

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,2 @@
+(builtins.getFlake (toString ./.)).devShells.${builtins.currentSystem}.default
+


### PR DESCRIPTION
# Context
This PR is to automates/simplifies the steps for rebuilding v8. Closes https://linear.app/tezos/issue/JSTZ-829/simplify-and-automate-v8-build

Unfortunately, my attempt to some what nixify the build environment (https://github.com/jstz-dev/rusty_v8/pull/3) failed. I've given up on this side quest for now to get going on the main quest of lowering peak mem usage

# Description
This PR brings in tools required for the v8 build environment. It has a nix flake to bring in the minimal set of build tools. Additionally, `setup.sh` file pulls in a static cross compiled riscv64 toolchain. This needed to be done as the on provisioned by nix is perhaps too minimal / doesn't conform to conventional structure for the v8 build, although this needs to be investigated.

# Manual Testing
To test, you need a linux machine that has nix installed.
`nix develop`
`./setup.sh`
`./build.sh`

GN args can be configured via `args.gn`
