### PR TITLE
feat: align caged heap to page size

### DIFF
--- a/0005_V8_ALIGN_CAGED_HEAP_TO_PAGE_SIZE.patch
+++ b/0005_V8_ALIGN_CAGED_HEAP_TO_PAGE_SIZE.patch
@@ -1,0 +1,13 @@
+diff --git a/include/cppgc/internal/api-constants.h b/include/cppgc/internal/api-constants.h
+index 8a0bb082fb..28b6b09464 100644
+--- a/include/cppgc/internal/api-constants.h
++++ b/include/cppgc/internal/api-constants.h
+@@ -70,7 +70,7 @@ constexpr size_t kCagedHeapMaxReservationSize =
+     kCagedHeapDefaultReservationSize;
+ #endif  // !defined(CPPGC_POINTER_COMPRESSION)
+ #endif  // !defined(CPPGC_2GB_CAGE)
+-constexpr size_t kCagedHeapReservationAlignment = kCagedHeapMaxReservationSize;
++constexpr size_t kCagedHeapReservationAlignment = kPageSize;
+ #endif  // defined(CPPGC_CAGED_HEAP)
+ 
+ static constexpr size_t kDefaultAlignment = sizeof(void*);

--- a/setup.sh
+++ b/setup.sh
@@ -23,6 +23,7 @@ v8_patches=(
 	"0002_V8_PATCH_INTERNAL.patch"
 	"0003_V8_DO_NOT_FORCE_ENABLE_PTR_CMPRSN.patch"
 	"0004_V8_SWITCH_OFF_LARGER_CAGED_HEAPS.patch"
+	"0005_V8_ALIGN_CAGED_HEAP_TO_PAGE_SIZE.patch"
 )
 cd v8
 for patch in "${v8_patches[@]}"; do


### PR DESCRIPTION
# Context
`OS::Allocate` allows callers to specify the `alignment` of  the return base address of the memory block. Arbitrary alignment is not supported in standard systems. For v8 to support this, they over allocate by as much as `alignment` then search for the first aligned address, which increase the peak memory by `alignment`. 

By default, when the caged heap is allocated, it returns an address that is aligned to the size of the cage heap, resulting in peak memory being at least 2x size. Even though the alignment requirement is only required for pointer compressed cages, it is set by default irregardless - I suspect this is done because over allocating virtual memory under normal circumstances is negligible and thus, it was just overlooked.

This PR fixes that by aligning the caged heap to `kPageSize` by default. Note that `kPageSize` is not the page size of the machine but the page size of the v8 managed heap which is 128KiB

In terms of correctness, initial test look promising but we should increase our testing surface to increase confidence. Additionally, there is a noticeable slowdown with switching off pointer compression and un-aligned cages (not sure which is causing it)


Previous TPS

10 FA2 transfers took 8.903883855s @ 1.123 TPS


New TPS

10 FA2 transfers took 8.699510309s @ 1.149 TPS

Part of https://linear.app/tezos/issue/JSTZ-839/align-caged-heap-to-page-size-by-default

# Description
Sets default alignment to`kPageSize`

# Manual testing
See Manual testing section of jstz PR https://github.com/jstz-dev/jstz/pull/1245. 


# Results
~40% reduction
## Previous
```
total runtime: 5.014000s.
calls to allocation functions: 3562347 (710480/s)
temporary memory allocations: 485098 (96748/s)
peak heap memory consumption: 1.23G
peak RSS (including heaptrack overhead): 10.01G
total memory leaked: 7.90M
```
## Current
```
total runtime: 3.929000s.
calls to allocation functions: 3516312 (894963/s)
temporary memory allocations: 469705 (119548/s)
peak heap memory consumption: 1.23G
peak RSS (including heaptrack overhead): 5.99G
total memory leaked: 7.85M
```